### PR TITLE
Extract hardcoded information to config file

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Config where
+
+import Data.Text (Text)
+import Data.Map (fromList, findWithDefault)
+
+data Config = Config {
+  mp4FilesDirectory :: Text,
+  mp3FilesDirectory :: Text,
+  editInputFilesDirectory :: Text,
+  editOutputFilesDirectory :: Text,
+  editTemplatesDirectory :: Text,
+  introFileName :: Text
+}
+
+defaultEditingFileName :: Text
+defaultEditingFileName = "BSV INTRO - ONSITE.mp3"
+
+editTemplatesMap = fromList [
+    ("nbm", "NBM INTRO.mp3"),
+    ("bsv-on", "BSV INTRO - ONSITE.mp3"),
+    ("bsv-off", "BSV INTRO - OFFSITE.mp3")
+  ]
+
+defaultConfig = Config {
+  mp4FilesDirectory = "/Users/Ken/Downloads/convert/mp4/",
+  mp3FilesDirectory = "/Users/Ken/Downloads/convert/mp3/",
+  editInputFilesDirectory = "/Users/Ken/Downloads/convert/edit/",
+  editOutputFilesDirectory = "/Users/Ken/Downloads/convert/final/",
+  editTemplatesDirectory = "/Users/Ken/Documents/Buddhist/Editing Templates/",
+  introFileName = findWithDefault defaultEditingFileName "nbm" editTemplatesMap
+}

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -8,23 +8,17 @@ import Turtle.Prelude (find, proc)
 import Turtle.Shell (Shell, foldIO)
 import Turtle.Pattern (suffix)
 import Turtle.Format (format, fp)
-import Data.Maybe (fromMaybe)
-import Data.Text (stripSuffix)
-
-stripMp4Suffix :: Turtle.Text -> Turtle.Text
-stripMp4Suffix file = fromMaybe file (stripSuffix ".mp4" file)
-
-createOutputFileName :: Turtle.Text -> Turtle.Text
-createOutputFileName filePath = stripMp4Suffix filePath <> ".mp3"
+import Config (defaultConfig, mp4FilesDirectory, mp3FilesDirectory)
 
 createArguments :: Turtle.FilePath -> [Turtle.Text]
 createArguments filePath =
-  let inputFileName = format fp filePath
-      outputFileName = createOutputFileName inputFileName
+  let baseFileName = Turtle.basename filePath
+      inputFileName = format fp filePath
+      outputFileName = mp3FilesDirectory defaultConfig <> format fp baseFileName <> ".mp3"
   in ["-i", inputFileName, "-q:a", "0",  "-map", "a", outputFileName]
 
 getMP4Files :: Shell Turtle.FilePath
-getMP4Files = find (suffix ".mp4") "/Users/Ken/Downloads/convert"
+getMP4Files = find (suffix ".mp4") $ Turtle.fromText $ mp4FilesDirectory defaultConfig
 
 runCommand :: Turtle.FilePath -> IO ()
 runCommand filePath = proc "ffmpeg" (createArguments filePath) Turtle.empty >>= print

--- a/app/Stitch.hs
+++ b/app/Stitch.hs
@@ -6,38 +6,22 @@ import qualified Turtle
 import qualified Control.Foldl as L
 import Turtle.Prelude (find, proc)
 import Turtle.Shell (Shell, foldIO)
-import Turtle.Pattern (suffix, has, text, Pattern)
+import Turtle.Pattern (suffix)
 import Turtle.Format (format, fp)
-import Data.Maybe (fromMaybe)
-import Data.Text (stripSuffix)
-import Data.Map (fromList, findWithDefault)
-
-introTemplateMap = fromList([("nbm", "INTRO.mp3"), ("bsv", "ONSITE.mp3")])
-
-getIntroFile :: Turtle.Text -> Pattern Turtle.Text
-getIntroFile fileName = text (findWithDefault "ONSITE.mp3" fileName introTemplateMap)
-
-stripMp3Suffix :: Turtle.Text -> Turtle.Text
-stripMp3Suffix file = fromMaybe file (stripSuffix ".mp3" file)
-
-createOutputFileName :: Turtle.Text -> Turtle.Text
-createOutputFileName filePath = stripMp3Suffix filePath <> "-final.mp3"
+import Config (defaultConfig, editInputFilesDirectory, editOutputFilesDirectory, editTemplatesDirectory, introFileName)
 
 getMP3Files :: Shell Turtle.FilePath
-getMP3Files = find (suffix ".mp3") "/Users/Ken/Downloads/convert/stitch"
+getMP3Files = find (suffix ".mp3") $ Turtle.fromText $ editInputFilesDirectory defaultConfig
 
-getOpeningFile :: Shell Turtle.FilePath
-getOpeningFile = find (has (getIntroFile "nbm")) "/Users/Ken/Documents/Buddhist/Editing Templates"
-
-createArguments :: Turtle.FilePath -> Turtle.FilePath -> [Turtle.Text]
-createArguments openingFilePath mainFilePath =
-  let openingFileName = format fp openingFilePath
+createArguments :: Turtle.FilePath -> [Turtle.Text]
+createArguments mainFilePath =
+  let openingFileName = editTemplatesDirectory defaultConfig <> introFileName defaultConfig
       mainFileName = format fp mainFilePath
-      outputFileName = createOutputFileName mainFileName
+      outputFileName = editOutputFilesDirectory defaultConfig <> format fp (Turtle.filename mainFilePath)
   in ["-i", openingFileName, "-i", mainFileName, "-filter_complex", "concat=n=2:v=0:a=1", outputFileName]
 
-runCommand :: (Turtle.FilePath, Turtle.FilePath) -> IO ()
-runCommand (f1, f2) = proc "ffmpeg" (createArguments f1 f2) Turtle.empty >>= print
+runCommand :: Turtle.FilePath -> IO ()
+runCommand filePath = proc "ffmpeg" (createArguments filePath) Turtle.empty >>= print
 
 stitch :: IO ()
-stitch = foldIO (Turtle.liftA2 (,) getOpeningFile getMP3Files) (L.sink runCommand)
+stitch = foldIO getMP3Files (L.sink runCommand)


### PR DESCRIPTION
# Reason

We have a lot of hardcoded values littered throughout the code...which is fine for now. Extracting them to a common configuration file makes sense so that we only ever need to modify the 1 file if we need to. 

